### PR TITLE
fix: parse span threads correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Parsing of *SpanExit* records ([#3](https://github.com/soehrl/tracing-tape/pull/3/))
+- Parsing of Threads only used for spans ([#4](https://github.com/soehrl/tracing-tape/pull/4/))
 
 
 ## [0.1.0] - 2024-11-10

--- a/tracing-tape-parser/src/lib.rs
+++ b/tracing-tape-parser/src/lib.rs
@@ -229,6 +229,10 @@ impl Intermediate {
     fn enter_span<'a>(&mut self, slice: &'a [u8]) -> &'a [u8] {
         let span_enter_record = SpanEnterRecord::ref_from_prefix(slice).unwrap();
 
+        self.threads
+            .entry(span_enter_record.thread_id.get())
+            .or_insert(None);
+
         let index = self.opened_spans[&span_enter_record.id.get()];
         let span = &mut self.span_graph[index];
         span.entrances.push(SpanEntrance {


### PR DESCRIPTION
This PR fixes a bug where a thread would not be parsed correctly if it was only used to record spans and no log messages.