### PR TITLE
fix: reported tape time range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Parsing of *SpanExit* records ([#3](https://github.com/soehrl/tracing-tape/pull/3/))
 - Parsing of Threads only used for spans ([#4](https://github.com/soehrl/tracing-tape/pull/4/))
+- Reported tape time range ([#5](https://github.com/soehrl/tracing-tape/pull/5/))
 
 
 ## [0.1.0] - 2024-11-10

--- a/tracing-tape-parser/src/lib.rs
+++ b/tracing-tape-parser/src/lib.rs
@@ -710,9 +710,8 @@ impl Tape {
     }
 
     pub fn time_range(&self) -> std::ops::RangeInclusive<i128> {
-        let base = self.intro.timestamp_base.get();
-        let start = base + self.data.min_timestamp as i128;
-        let end = base + self.data.max_timestamp as i128;
+        let start = self.intro.timestamp_base.get();
+        let end = start + self.data.max_timestamp as i128;
         start..=end
     }
 


### PR DESCRIPTION
This PR solves a bug where the reported time range of a tape would report the start time of the first record and not the creation of the tape.