### PR TITLE
feat(format): derive Debug, Clone, and Copy traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - This CHANGELOG file that will contain all notable changes to this project ([#2](https://github.com/soehrl/tracing-tape/pull/2/))
+- Derive the `Debug`, `Clone`, and `Copy` traits for all structs in the `tracing-tape` crate ([#11](https://github.com/soehrl/tracing-tape/pull/11/))
 
 ### Fixed
 - Parsing of *SpanExit* records ([#3](https://github.com/soehrl/tracing-tape/pull/3/))

--- a/tracing-tape/src/record/callsite.rs
+++ b/tracing-tape/src/record/callsite.rs
@@ -2,7 +2,7 @@ use zerocopy::{little_endian, AsBytes, FromBytes, FromZeroes, Unaligned};
 
 use super::{record_kind, RecordHeader};
 
-#[derive(Debug, AsBytes, FromZeroes, FromBytes, Unaligned)]
+#[derive(Debug, Clone, Copy, AsBytes, FromZeroes, FromBytes, Unaligned)]
 #[repr(transparent)]
 pub struct CallsiteInfo(u8);
 
@@ -73,7 +73,7 @@ impl CallsiteInfo {
     }
 }
 
-#[derive(Debug, AsBytes, FromZeroes, FromBytes, Unaligned)]
+#[derive(Debug, Clone, Copy, AsBytes, FromZeroes, FromBytes, Unaligned)]
 #[repr(C)]
 pub struct CallsiteRecord {
     pub header: RecordHeader,
@@ -114,7 +114,7 @@ impl CallsiteRecord {
     }
 }
 
-#[derive(Debug, AsBytes, FromZeroes, FromBytes, Unaligned)]
+#[derive(Debug, Clone, Copy, AsBytes, FromZeroes, FromBytes, Unaligned)]
 #[repr(C)]
 pub struct CallsiteFieldRecord {
     pub header: RecordHeader,

--- a/tracing-tape/src/record/event.rs
+++ b/tracing-tape/src/record/event.rs
@@ -2,7 +2,7 @@ use zerocopy::{little_endian, AsBytes, FromBytes, FromZeroes, Unaligned};
 
 use super::{record_kind, RecordHeader};
 
-#[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
+#[derive(Debug, Clone, Copy, AsBytes, FromZeroes, FromBytes, Unaligned)]
 #[repr(C)]
 pub struct EventRecord {
     pub header: RecordHeader,
@@ -24,7 +24,7 @@ impl EventRecord {
     }
 }
 
-#[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
+#[derive(Debug, Clone, Copy, AsBytes, FromZeroes, FromBytes, Unaligned)]
 #[repr(C)]
 pub struct EventValueRecord {
     pub header: RecordHeader,

--- a/tracing-tape/src/record/mod.rs
+++ b/tracing-tape/src/record/mod.rs
@@ -28,7 +28,7 @@ pub mod record_kind {
     pub const SPAN_FOLLOWS: u8 = 0x25;
 }
 
-#[derive(Debug, AsBytes, FromBytes, FromZeroes, Unaligned)]
+#[derive(Debug, Clone, Copy, AsBytes, FromBytes, FromZeroes, Unaligned)]
 #[repr(C)]
 pub struct RecordHeader {
     pub kind: u8,

--- a/tracing-tape/src/record/span.rs
+++ b/tracing-tape/src/record/span.rs
@@ -2,7 +2,7 @@ use zerocopy::{little_endian, AsBytes, FromBytes, FromZeroes, Unaligned};
 
 use super::{record_kind, RecordHeader};
 
-#[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
+#[derive(Debug, Clone, Copy, AsBytes, FromZeroes, FromBytes, Unaligned)]
 #[repr(C)]
 pub struct SpanOpenRecord {
     pub header: RecordHeader,
@@ -27,7 +27,7 @@ impl SpanOpenRecord {
     }
 }
 
-#[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
+#[derive(Debug, Clone, Copy, AsBytes, FromZeroes, FromBytes, Unaligned)]
 #[repr(C)]
 pub struct SpanCloseRecord {
     pub header: RecordHeader,
@@ -48,7 +48,7 @@ impl SpanCloseRecord {
     }
 }
 
-#[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
+#[derive(Debug, Clone, Copy, AsBytes, FromZeroes, FromBytes, Unaligned)]
 #[repr(C)]
 pub struct SpanEnterRecord {
     pub header: RecordHeader,
@@ -71,7 +71,7 @@ impl SpanEnterRecord {
     }
 }
 
-#[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
+#[derive(Debug, Clone, Copy, AsBytes, FromZeroes, FromBytes, Unaligned)]
 #[repr(C)]
 pub struct SpanExitRecord {
     pub header: RecordHeader,
@@ -92,7 +92,7 @@ impl SpanExitRecord {
     }
 }
 
-#[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
+#[derive(Debug, Clone, Copy, AsBytes, FromZeroes, FromBytes, Unaligned)]
 #[repr(C)]
 pub struct SpanValueRecord {
     pub header: RecordHeader,
@@ -115,7 +115,7 @@ impl SpanValueRecord {
     }
 }
 
-#[derive(AsBytes, FromZeroes, FromBytes, Unaligned)]
+#[derive(Debug, Clone, Copy, AsBytes, FromZeroes, FromBytes, Unaligned)]
 #[repr(C)]
 pub struct SpanFollowsRecord {
     pub header: RecordHeader,


### PR DESCRIPTION
Derive the `Debug`, `Clone`, and `Copy` traits for all structs. 